### PR TITLE
added from_date, to_date, env_id to ori_airline_alliance_membership.csv ...

### DIFF
--- a/refdata/ORI/ori_airline_alliance_membership.csv
+++ b/refdata/ORI/ori_airline_alliance_membership.csv
@@ -1,92 +1,103 @@
-alliance_name^alliance_type^airline_iata_code_2c^airline_name
-OneWorld^Member^AB^Air Berlin
-OneWorld^Affiliate^HG^Niki
-OneWorld^Member^AA^American Airlines
-OneWorld^Affiliate^OW^Executive Airlines
-OneWorld^Affiliate^AX^Trans States Airlines
-OneWorld^Member^BA^British Airways
-OneWorld^Affiliate^CJ^BA CityFlyer
-OneWorld^Affiliate^MN^Comair
-OneWorld^Affiliate^EC^OpenSkies
-OneWorld^Affiliate^EZ^Sun Air of Scandinavia
-OneWorld^Member^CX^Cathay Pacific
-OneWorld^Affiliate^KA^Dragonair
-OneWorld^Member^AY^Finnair
-OneWorld^Member^IB^Iberia
-OneWorld^Affiliate^YW^Air Nostrum
-OneWorld^Affiliate^I2^Iberia Express
-OneWorld^Member^JL^Japan Airlines
-OneWorld^Affiliate^XM^J-Air
-OneWorld^Affiliate^JC^JAL Express
-OneWorld^Member^NU^Japan Transocean Air
-OneWorld^Member^LA^LATAM Airlines Group
-OneWorld^Affiliate^4M^LAN Argentina
-OneWorld^Affiliate^XL^LAN Ecuador
-OneWorld^Affiliate^LU^LAN Express
-OneWorld^Affiliate^LP^LAN Peru
-OneWorld^Member^QF^Qantas Airways
-OneWorld^Affiliate^NC^Cobham Aviation Services Australia
-OneWorld^Member^RJ^Royal Jordanian
-OneWorld^Member^S7^S7 Airlines
-OneWorld^Affiliate^GH^Globus
-OneWorld^Future^QR^Qatar Airways
-OneWorld^Future^UL^SriLankan Airlines
-OneWorld^Member^MH^Malaysia Airlines
-OneWorld^Future^IT^Kingfisher Airlines
-Skyteam^Member^SU^Aeroflot
-Skyteam^Affiliate^D9^Donavia
-Skyteam^Member^AR^Aerolineas Argentinas
-Skyteam^Affiliate^AU^Austral Lineas Aereas
-Skyteam^Member^AM^AeroMexico
-Skyteam^Affiliate^5D^Aerolitoral
-Skyteam^Member^UX^Air Europa
-Skyteam^Member^AF^Air France
-Skyteam^Affiliate^DB^HOP Brit Air
-Skyteam^Affiliate^WX^CityJet
-Skyteam^Affiliate^YS^HOP Regional
-Skyteam^Member^AZ^Alitalia
-Skyteam^Affiliate^CT^Alitalia CityLiner
-Skyteam^Member^CI^China Airlines
-Skyteam^Affiliate^AE^Mandarin Airlines
-Skyteam^Member^MU^China Eastern Airlines
-Skyteam^Affiliate^FM^Shanghai Airlines
-Skyteam^Member^CZ^China Southern Airlines
-Skyteam^Member^OK^Czech Airlines
-Skyteam^Member^DL^Delta Air Lines
-Skyteam^Member^KQ^Kenya Airways
-Skyteam^Member^KL^KLM Royal Dutch Airlines
-Skyteam^Member^KE^Korean Air
-Skyteam^Member^ME^Middle East Airlines
-Skyteam^Member^SV^Saudi Arabian Airlines
-Skyteam^Member^RO^Tarom
-Skyteam^Member^VN^Vietnam Airlines
-Skyteam^Member^MF^Xiamen Airlines
-Skyteam^Future^GA^Garuda Indonesia
-Star Alliance^Member^A3^Aegean Airlines
-Star Alliance^Member^AC^Air Canada
-Star Alliance^Member^CA^Air China
-Star Alliance^Member^CL^Lufthansa CityLine
-Star Alliance^Member^CM^Copa Airlines
-Star Alliance^Member^ET^Ethiopian Airlines
-Star Alliance^Member^JJ^TAM Linhas Aereas
-Star Alliance^Member^JP^Adria Airways
-Star Alliance^Member^LH^Lufthansa
-Star Alliance^Member^LO^LOT Polish Airlines
-Star Alliance^Member^LX^Swiss International Airlines
-Star Alliance^Member^NH^All Nippon Airways
-Star Alliance^Member^NZ^Air New Zealand
-Star Alliance^Member^OS^Austrian Airlines
-Star Alliance^Member^OU^Croatia Airlines
-Star Alliance^Member^OZ^Asiana Airlines
-Star Alliance^Member^US^US Airways
-Star Alliance^Member^MS^Egyptair
-Star Alliance^Member^SA^South African Airways
-Star Alliance^Member^SK^Scandinavian Airlines
-Star Alliance^Member^SN^Brussels Airlines
-Star Alliance^Member^SQ^Singapore Airlines
-Star Alliance^Member^TA^TACA International Airlines
-Star Alliance^Member^TG^Thai Airways International
-Star Alliance^Member^TK^Turkish Airlines
-Star Alliance^Member^TP^TAP Portugal
-Star Alliance^Member^UA^United Airlines
-Star Alliance^Member^ZH^Shenzhen Airlines
+alliance_name^alliance_type^airline_iata_code_2c^airline_name^from_date^to_date^env_id
+OneWorld^Member^AB^Air Berlin^2012-03-20^^
+OneWorld^Affiliate^HG^Niki^2012-03-20^^
+OneWorld^Member^AA^American Airlines^1999-02-01^^
+OneWorld^Affiliate^MQ^American Eagle^1999-02-01^^
+OneWorld^Affiliate^OW^Executive Airlines^1999-02-01^^
+OneWorld^Affiliate^AX^Trans States Airlines^1999-02-01^^
+OneWorld^Affiliate^US^US Airways^2014-03-31^^
+OneWorld^Member^BA^British Airways^1999-02-01^^
+OneWorld^Affiliate^CJ^BA CityFlyer^1999-02-01^^
+OneWorld^Affiliate^MN^Comair^1999-02-01^^
+OneWorld^Affiliate^EC^OpenSkies^1999-02-01^^
+OneWorld^Affiliate^EZ^Sun Air of Scandinavia^1999-02-01^^
+OneWorld^Member^CX^Cathay Pacific^1999-02-01^^
+OneWorld^Affiliate^KA^Dragonair^2007-11-01^^
+OneWorld^Member^AY^Finnair^1999-09-01^^
+OneWorld^Member^IB^Iberia^1999-09-01^^
+OneWorld^Affiliate^YW^Air Nostrum^1999-09-01^^
+OneWorld^Affiliate^I2^Iberia Express^2012-03-25^^
+OneWorld^Member^JL^Japan Airlines^2007-04-01^^
+OneWorld^Affiliate^XM^J-Air^2007-04-01^^
+OneWorld^Affiliate^JC^JAL Express^2007-04-01^^
+OneWorld^Affiliate^NU^Japan Transocean Air^2007-04-01^^
+OneWorld^Member^LA^LAN Airlines^2000-06-01^^
+OneWorld^Affiliate^4M^LAN Argentina^2007-04-01^^
+OneWorld^Affiliate^4C^LAN Columbia^2013-10-01^^
+OneWorld^Affiliate^XL^LAN Ecuador^2007-04-01^^
+OneWorld^Affiliate^LU^LAN Express^2000-06-01^^
+OneWorld^Affiliate^LP^LAN Peru^2000-06-01^^
+OneWorld^Member^JJ^TAM^2014-04-01^^
+OneWorld^Member^QF^Qantas Airways^1999-02-01^^
+OneWorld^Affiliate^NC^Cobham Aviation Services Australia^2005-06-01^^
+OneWorld^Member^RJ^Royal Jordanian^2007-04-01^^
+OneWorld^Member^S7^S7 Airlines^2010-11-15^^
+OneWorld^Affiliate^GH^Globus^2008-12-01^^
+OneWorld^Member^QR^Qatar Airways^2013-10-30^^
+OneWorld^Member^UL^SriLankan Airlines^2014-05-01^^
+OneWorld^Member^MH^Malaysia Airlines^2013-02-01^^
+Skyteam^Member^SU^Aeroflot^2006-04-14^^
+Skyteam^Affiliate^D9^Donavia^2006-04-14^^
+Skyteam^Member^AR^Aerolineas Argentinas^2012-08-29^^
+Skyteam^Affiliate^AU^Austral Lineas Aereas^2012-08-29^^
+Skyteam^Member^AM^AeroMexico^2000-06-22^^
+Skyteam^Affiliate^5D^Aeromexico Connect^2000-06-22^^
+Skyteam^Member^UX^Air Europa^2007-09-04^^
+Skyteam^Member^AF^Air France^2000-06-22^^
+Skyteam^Affiliate^AS^HOP!^2013-03-31^^
+Skyteam^Affiliate^DB^HOP Brit Air^2000-06-22^2013-03-30^1
+Skyteam^Affiliate^WX^CityJet^2000-06-22^^
+Skyteam^Affiliate^YS^HOP Regional^^2013-03-30^1
+Skyteam^Member^AZ^Alitalia^2001-07-27^^
+Skyteam^Affiliate^CT^Alitalia City Liner^2006-06-01^^
+Skyteam^Member^CI^China Airlines^2011-09-28^^
+Skyteam^Affiliate^AE^Mandarin Airlines^2011-09-28^^
+Skyteam^Member^MU^China Eastern Airlines^2011-06-21^^
+Skyteam^Affiliate^FM^Shanghai Airlines^2011-06-21^^
+Skyteam^Member^CZ^China Southern Airlines^2007-11-15^^
+Skyteam^Member^CO^Continental Airlines^2004-09-13^2009-10-24^1
+Skyteam^Member^OK^Czech Airlines^2001-03-25^^
+Skyteam^Member^DL^Delta Air Lines^2000-06-22^^
+Skyteam^Member^KQ^Kenya Airways^2007-09-04^^
+Skyteam^Member^KL^KLM Royal Dutch Airlines^2004-09-13^^
+Skyteam^Member^KE^Korean Air^2000-06-22^^
+Skyteam^Member^ME^Middle East Airlines^2012-06-28^^
+Skyteam^Member^NW^Northwest Airlines^2004-09-13^2010-01-31^1
+Skyteam^Member^SV^Saudi Arabian Airlines^2012-05-29^^
+Skyteam^Member^RO^Tarom^2010-06-25^^
+Skyteam^Member^VN^Vietnam Airlines^2010-06-10^^
+Skyteam^Member^MF^Xiamen Airlines^2012-11-21^^
+Skyteam^Member^GA^Garuda Indonesia^2014-03-05^^
+Star Alliance^Member^A3^Aegean Airlines^2010-06-01^^
+Star Alliance^Member^AC^Air Canada^1997-05-01^^
+Star Alliance^Member^AV^Avianca^2012-06-01^^
+Star Alliance^Member^BR^Eva Air^2013-06-01^^
+Star Alliance^Member^CA^Air China^2007-12-01^^
+Star Alliance^Member^CO^Continental Airlines^2009-10-27^2012-03-03^2
+Star Alliance^Affiliate^CL^Lufthansa CityLine^^^
+Star Alliance^Member^CM^Copa Airlines^2012-06-01^^
+Star Alliance^Member^ET^Ethiopian Airlines^2011-12-01^^
+Star Alliance^Member^JJ^TAM Linhas Aereas^2010-05-01^2014-03-31^1
+Star Alliance^Member^JK^Spanair^2003-05-01^2012-01-27^1
+Star Alliance^Member^JP^Adria Airways^2004-11-01^^
+Star Alliance^Member^KF^Blue One^^2012-11-30^1
+Star Alliance^Member^LH^Lufthansa^1999-05-01^^
+Star Alliance^Member^LO^LOT Polish Airlines^2003-10-01^^
+Star Alliance^Member^LX^Swiss International Airlines^2006-04-01^^
+Star Alliance^Member^MS^Egyptair^2008-06-01^^
+Star Alliance^Member^NH^All Nippon Airways^1999-10-01^^
+Star Alliance^Member^NZ^Air New Zealand^1999-03-01^^
+Star Alliance^Member^OS^Austrian Airlines^2000-03-01^^
+Star Alliance^Member^OU^Croatia Airlines^2004-11-01^^
+Star Alliance^Member^OZ^Asiana Airlines^2003-03-01^^
+Star Alliance^Member^SA^South African Airways^2006-04-01^^
+Star Alliance^Member^SK^Scandinavian Airlines^1997-05-01^^
+Star Alliance^Member^SN^Brussels Airlines^2009-12-01^^
+Star Alliance^Member^SQ^Singapore Airlines^2000-04-01^^
+Star Alliance^Member^TA^TACA International Airlines^2012-06-01^2013-05-21^1
+Star Alliance^Member^TG^Thai Airways International^1997-05-01^^
+Star Alliance^Member^TK^Turkish Airlines^2008-04-01^^
+Star Alliance^Member^TP^TAP Portugal^2005-03-01^^
+Star Alliance^Member^UA^United Airlines^1997-05-01^^
+Star Alliance^Member^US^US Airways^2004-05-01^2014-03-31^1
+Star Alliance^Member^ZH^Shenzhen Airlines^2012-11-01^^


### PR DESCRIPTION
...and updated alliance memberships.

This is a follow up to https://github.com/opentraveldata/optd/pull/22. From_date and to_date indicate when an airline joined / left the alliance. The env_id field indicates the version of the entry:
- An empty field marks the current version
- An integer value marks an older revision (starting from 1)
