### PR TITLE
New airlines and some port fixes

### DIFF
--- a/refdata/ORI/ori_airline_best_known_so_far.csv
+++ b/refdata/ORI/ori_airline_best_known_so_far.csv
@@ -717,6 +717,7 @@ air-niki^^^^NLY^HG^0^Niki^Niki^OneWorld^Affiliate^^
 air-nile-air^^^^NIA^NP^325^Nile Air^Nile Air^^^^
 air-nok-air^^^^^DD^0^Nok Air^^^^^
 air-non-iata-codeshare-carrier^^^^^XH^0^Non Iata Codeshare Carrier^^^^^
+air-norcopter^^^^noc^^^Norcopter^Norcopter^^^^http://en.wikipedia.org/wiki/Norcopter
 air-nordavia^^^^AUL^5N^316^Jsc Nordavia^Jsc Nordavia^^^^
 air-nord-wind^^^^NWS^N4^0^Nord Wind^^^^^
 air-nordic-global-airlines^^2011-04-01^^NGB^NJ^0^Nordic Global Airlines^^^^C^http://en.wikipedia.org/wiki/Nordic_Global_Airlines

--- a/refdata/ORI/ori_airline_best_known_so_far.csv
+++ b/refdata/ORI/ori_airline_best_known_so_far.csv
@@ -814,6 +814,7 @@ air-rossiya-airlines^^^^SDM^FV^195^Rossiya Airlines^Rossiya^^^^
 air-rotana-jet^^2011-04-18^^RJD^RG^482^Rotana Jet^Rotana Jet^^^^http://en.wikipedia.org/wiki/Rotana_Jet
 air-royal-air-force^^^^RFR^RR^0^Royal Air Force^RAF NO^^^^
 air-royal-air-maroc^^^^RAM^AT^147^Royal Air Maroc^Royal Air Maroc^^^^
+air-royal-air-force-au^^^^ASY^^^Royal Australian Air Force^Royal Australian Air Force^^^^http://en.wikipedia.org/wiki/Royal_Australian_Air_Force
 air-royal-brunei^^^^RBA^BI^672^Royal Brunei^Royalbrunei^^^^
 air-royal-falcon^^^^RFJ^RL^372^Royal Falcon^^^^^
 air-royal-jordanian^^^^RJA^RJ^512^Royal Jordanian^Ryljordania^OneWorld^Member^^


### PR DESCRIPTION
Some airlines observed in Australian air space (yes, including NOC!). Not sure if their codes are ICAO-approved or only used in Australia. Where could I check that?

Regarding FAOR/FAJS, I guess just replacing one by another is not the best solution. Should I add a new line? Let me know and I update the PR. FAJS is no longer valid as of 10 January 2013 [1].

[1] http://en.wikipedia.org/wiki/O._R._Tambo_International_Airport
